### PR TITLE
Fix parsing failure for empty line comments.

### DIFF
--- a/bestform.cs/Lang.cs
+++ b/bestform.cs/Lang.cs
@@ -635,7 +635,7 @@ namespace BestForm.CS
             def = GenLanguageDef.Empty.With(
                 CommentStart: "/*",
                 CommentEnd: "*/",
-                CommentLine: "// ",
+                CommentLine: "//",
                 NestedComments: false,
                 IdentStart: choice(letter, ch('_'), ch('@')),
                 IdentLetter: either(alphaNum, oneOf("_'")),


### PR DESCRIPTION
Paragraphs separated by a blank comment would cause doc gen to
fail unless a single space was inserted after the comment.

// For
//
// example